### PR TITLE
fix: add types for graceful-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
         "@babel/preset-react": "^7.9.4",
         "@babel/preset-typescript": "^7.9.0",
         "@jest/types": "^25.2.6",
+        "@types/graceful-fs": "^4.1.3",
         "@types/jest": "^25.2.1",
         "@types/node": "^13.11.0",
         "eslint": "^6.8.0",


### PR DESCRIPTION
Something in Jest depends on these types, but doesn't ship them to us.