### PR TITLE
fix(test): suppress jest require cache warning

### DIFF
--- a/packages/e2e/src/index.ts
+++ b/packages/e2e/src/index.ts
@@ -152,7 +152,12 @@ function configForTestSuite(suite: JestSuite) {
   }
 }
 
+declare var jest : never;
 function purgeRequireCache(files: string[]) {
+  // Jest returns an annoying warning if we try to purge the cache
+  // while being tested.
+  if (typeof jest !== 'undefined')
+    return;
   const blackList = new Set(files);
   for (const filePath of Object.keys(require.cache)) {
     /** @type {NodeModule|null|undefined} */


### PR DESCRIPTION
After https://github.com/facebook/jest/pull/9855, jest complains about our require magic. This only effects our internal tests. Jest already clears the cache between each run for us. It is ok to just disable the code.