### PR TITLE
feat: use launch and context options from config

### DIFF
--- a/packages/demo/e2e/page.spec.js
+++ b/packages/demo/e2e/page.spec.js
@@ -5,3 +5,7 @@ it('is a basic test with the page', async ({page}) => {
 it('is not firefox', async ({page}) => {
   expect(await page.evaluate(() => navigator.userAgent)).toContain('WebKit');
 });
+it('should use the window width and height from the playwight.config.js', async ({ page }) => {
+  expect(await page.evaluate(() => window.innerWidth)).toBe(1234);
+  expect(await page.evaluate(() => window.innerHeight)).toBe(789);
+});

--- a/packages/demo/jest.config.js
+++ b/packages/demo/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
+  rootDir: '.',
   preset: 'playwright-runner',
 };

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -2,6 +2,9 @@
   "name": "demo",
   "version": "0.0.0",
   "private": true,
+  "scripts": {
+    "test": "jest"
+  },
   "dependencies": {
     "react": "^16.13.1",
     "react-dom": "^16.13.1"

--- a/packages/demo/playwright.config.js
+++ b/packages/demo/playwright.config.js
@@ -1,3 +1,9 @@
 module.exports = {
   browsers: ['chromium', 'webkit'],
+  contextOptions: {
+    viewport: {
+      width: 1234,
+      height: 789,
+    },
+  },
 };

--- a/packages/e2e/src/index.ts
+++ b/packages/e2e/src/index.ts
@@ -8,7 +8,7 @@ import * as globals from './globals';
 import playwright from 'playwright';
 import {createSuite, beforeEach, afterEach} from 'describers';
 import path from 'path';
-import {validate} from 'jest-validate';
+import {validate, ValidationError} from 'jest-validate';
 
 // TODO: figure out hook timeouts.
 const NoHookTimeouts = 0;
@@ -165,13 +165,14 @@ function configForTestSuite(rootDir: string): UserConfig {
   try {
     const localConfig = require(path.join(rootDir, 'playwright.config'));
     validate(localConfig, {
-      exampleConfig: DEFAULT_CONFIG
+      exampleConfig: DEFAULT_CONFIG,
+      recursiveBlacklist: ["launchOptions", "contextOptions"]
     });
     return {
       ...DEFAULT_CONFIG,
       ...localConfig
     } as UserConfig
-  } catch (err) {
+  } catch {
   }
   return DEFAULT_CONFIG
 }

--- a/packages/e2e/tests/mock.spec.js
+++ b/packages/e2e/tests/mock.spec.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const {fakeJestRun} = require('./fakeJestRun');
-it('should report the corret number of tests', async function() {
+it('should report the correct number of tests', async function() {
   const result = await fakeJestRun(['oneTest.js', 'twoTests.js']);
   expect(result.numTotalTests).toBe(3);
   expect(result.numPassedTests).toBe(3);
@@ -9,7 +9,7 @@ it('should report the corret number of tests', async function() {
   expect(result.success).toBe(true);
 });
 
-it('should report the corret file name for the test', async function() {
+it('should report the correct file name for the test', async function() {
   const result = await fakeJestRun(['oneTest.js']);
   expect(result.testResults[0].testFilePath).toEqual(path.join(__dirname, 'assets', 'oneTest.js'));
 });

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  browsers: ['chromium', 'webkit'],
+  contextOptions: {
+    viewport: {
+      width: 1234,
+      height: 789,
+    },
+  },
+};


### PR DESCRIPTION
Doing the basic stuff for having and overwriting context and launch options from the config. I'm not fully sure, how we should structure it, so that it can be passed in the end to the launch / newContext functions.

The config needs to be accessed in the createSuite callback, so maybe with passing the args to the root suite?