### PR TITLE
bump: Playwright to 0.16.0

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -7,7 +7,7 @@
     "expect": "^25.2.7",
     "jest-message-util": "^25.2.6",
     "jest-validate": "^25.5.0",
-    "playwright": "^0.14.0"
+    "playwright": "^0.16.0"
   },
   "version": "0.0.7",
   "description": "Runs end-to-end browser tests",

--- a/packages/superpowers/package.json
+++ b/packages/superpowers/package.json
@@ -4,7 +4,7 @@
   "description": "Injects playwright apis into a page.",
   "main": "out/index.js",
   "devDependencies": {
-    "playwright": "^0.14.0"
+    "playwright": "^0.16.0"
   },
   "license": "MIT",
   "dependencies": {},

--- a/packages/unit/package.json
+++ b/packages/unit/package.json
@@ -19,7 +19,7 @@
     "expect": "^25.2.7",
     "jest-message-util": "^25.3.0",
     "md5.js": "^1.3.5",
-    "playwright": "^0.14.0",
+    "playwright": "^0.16.0",
     "playwright-superpowers": "0.0.7"
   },
   "author": {


### PR DESCRIPTION
Maybe it makes sense to exclude `playwright` entirely from the project as we did in `jest-playwright`? So only playwright-core will be used for types.

So the user can decide which browser / npm package he wants to install in the end to save bandwidth. (`playwright` vs. `playwright-chromium` etc.)

Disadvantage for that is definitely that sometimes it can lead to issues if `playwright-runner` is not compatible with the latest Playwright version.