### PR TITLE
fix mock test

### DIFF
--- a/packages/e2e/tests/assets/twoTests.js
+++ b/packages/e2e/tests/assets/twoTests.js
@@ -21,5 +21,5 @@ it('is the first test', state => {
 
 it('is the second test', state => {
   expect(state.shared).toEqual(1);
-  expect(state.counter).toEqual(3);
+  expect(state.counter).toEqual(1);
 });

--- a/packages/e2e/tests/mock.spec.js
+++ b/packages/e2e/tests/mock.spec.js
@@ -2,6 +2,9 @@ const path = require('path');
 const {fakeJestRun} = require('./fakeJestRun');
 it('should report the corret number of tests', async function() {
   const result = await fakeJestRun(['oneTest.js', 'twoTests.js']);
+  result.testResults.map(r => {
+    r.failureMessage && console.log(r.failureMessage);
+  });
   expect(result.numTotalTests).toBe(3);
   expect(result.numPassedTests).toBe(3);
   expect(result.numFailedTests).toBe(0);


### PR DESCRIPTION
The beforeEach hooks have different semantics because state is copied instead of just passed into the next test.