### PR TITLE
docs: added basic examples

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -1,0 +1,24 @@
+name: Examples
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  test-examples:
+    strategy:
+      matrix:
+        dir: [basic-js, basic-ts, browser-device-matrix, record-video, screenshot-on-failure]
+    defaults:
+      run:
+        working-directory: examples/${{ matrix.dir }}
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: microsoft/playwright-github-action@v1
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - run: npm install
+    - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ yarn-error.log
 .vscode
 /packages/*/out/
 tsconfig.tsbuildinfo
+test-results/

--- a/README.md
+++ b/README.md
@@ -1,10 +1,23 @@
 # 🎭 Playwright Runner
-> :warning: **WARNING:** For testing in production please refer to the [Test runners](https://github.com/microsoft/playwright/blob/master/docs/test-runners.md) document. This repository contains an experimental test runner.
+> ⚠️ **WARNING:** For testing in production please refer to the [Test runners](https://github.com/microsoft/playwright/blob/master/docs/test-runners.md) document. This repository contains an experimental test runner.
+
+## Features
+
+- Support for Javascript and TypeScript
+- Abstracted logic support for running logic before and after a test called fixtures
+- New Playwright Context for each new test
+- Integration for running multiple browsers / devices via CLI and environment variables
+
+## Installation
+
+```
+npm i -D playwright-runner
+```
 
 ## Usage
 
-1. `npm i -D playwright-runner`
-2. Place unit tests in files ending with `.spec.*`.
+Place unit tests in files ending with `.spec.*`.
+
 ```js
 // src/foo.spec.ts
 import 'playwright-runner';
@@ -14,9 +27,18 @@ it('is a basic test with the page', async ({page}) => {
   expect(await page.innerText('.home-navigation')).toBe('🎭 Playwright');
 });
 ```
-3. Run all of your tests with `npx test-runner .`
 
-# Contributing
+Run all of your tests with `npx test-runner`
+
+## Examples
+
+- [Using JavaScript](./basic-js)
+- [Using TypeScript](./basic-ts)
+- [Recording Playwright tests (Chromium only)](./record-video)
+- [Creating screenshots on failure](./screenshot-on-failure)
+- [Run multiple browsers / devices](./browser-device-matrix)
+
+## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,1 @@
+yarn.lock

--- a/examples/basic-js/package.json
+++ b/examples/basic-js/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "playwright-basic-js",
+  "version": "1.0.0",
+  "directories": {
+    "test": "tests"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "playwright-runner": "^0.2.1"
+  },
+  "scripts": {
+    "test": "test-runner"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/examples/basic-js/tests/playwright.spec.js
+++ b/examples/basic-js/tests/playwright.spec.js
@@ -1,11 +1,11 @@
 /**
- * Copyright (c) Microsoft Corporation.
+ * Copyright Microsoft Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-require('../..');
+require('playwright-runner');
 
-it('slow', test => {
-  test.slow();
-}, async () => {
-  await new Promise(f => setTimeout(f, 10000));
+it('is a basic test with the page', async ({page}) => {
+  await page.goto('https://playwright.dev/');
+  expect(await page.innerText('.home-navigation')).toBe('🎭 Playwright');
 });

--- a/examples/basic-ts/package.json
+++ b/examples/basic-ts/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "playwright-basic-ts",
+  "version": "1.0.0",
+  "description": "",
+  "directories": {
+    "test": "tests"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "playwright-runner": "^0.2.1"
+  },
+  "scripts": {
+    "test": "test-runner"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/examples/basic-ts/tests/playwright.spec.ts
+++ b/examples/basic-ts/tests/playwright.spec.ts
@@ -1,11 +1,11 @@
 /**
- * Copyright (c) Microsoft Corporation.
+ * Copyright Microsoft Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-require('../..');
+import 'playwright-runner';
 
-it('slow', test => {
-  test.slow();
-}, async () => {
-  await new Promise(f => setTimeout(f, 10000));
+it('is a basic test with the page', async ({page}) => {
+  await page.goto('https://playwright.dev/');
+  expect(await page.innerText('.home-navigation')).toBe('🎭 Playwright');
 });

--- a/examples/browser-device-matrix/package.json
+++ b/examples/browser-device-matrix/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "playwright-browser-device-matrix",
+  "version": "1.0.0",
+  "description": "",
+  "directories": {
+    "test": "tests"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "playwright-runner": "^0.2.1"
+  },
+  "scripts": {
+    "test": "test-runner test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/examples/browser-device-matrix/test/playwright.spec.ts
+++ b/examples/browser-device-matrix/test/playwright.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {registerWorkerFixture} from 'playwright-runner';
+import playwright from 'playwright';
+
+declare global {
+  interface FixtureParameters {
+    deviceName: string;
+  }
+}
+
+registerWorkerFixture('deviceName', async ({}, test) => {
+  await test(null);
+});
+
+registerWorkerFixture('defaultContextOptions', async ({deviceName}, test) => {
+  const device = typeof deviceName === 'string' ? playwright.devices[deviceName] : deviceName;
+  await test({
+    ...device
+  });
+});
+
+it('is a basic test with the page', async ({page}) => {
+  await page.goto('http://whatsmyuseragent.org/');
+});

--- a/examples/browser-device-matrix/test/setup.ts
+++ b/examples/browser-device-matrix/test/setup.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare const matrix: (m: any) => void;
+
+matrix({
+  'browserName': process.env.BROWSER ? [process.env.BROWSER] : ['chromium', 'webkit'],
+  'deviceName': process.env.DEVICE ? [process.env.DEVICE] : ['iPhone 11 Pro Max', 'Pixel 2 XL', {
+    'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.3; en-us; SM-N900T Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
+    'viewport': {
+      'width': 360,
+      'height': 640
+    },
+    'deviceScaleFactor': 3,
+    'isMobile': true,
+    'hasTouch': true
+  }],
+});
+

--- a/examples/record-video/package.json
+++ b/examples/record-video/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "playwright-record-video",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "directories": {
+    "test": "tests"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@ffmpeg-installer/ffmpeg": "^1.0.20",
+    "playwright-runner": "^0.2.1",
+    "playwright-video": "^2.3.1"
+  },
+  "scripts": {
+    "test": "test-runner --timeout 30000"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/examples/record-video/tests/playwright.spec.ts
+++ b/examples/record-video/tests/playwright.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {registerFixture} from 'playwright-runner';
+import {saveVideo} from 'playwright-video';
+import path from 'path';
+
+registerFixture('page', async ({context}, runTest, info) => {
+  const page = await context.newPage();
+  const {test, config} = info;
+  const relativePath = path.relative(config.testDir, test.file).replace(/\.spec\.[jt]s/, '');
+  const sanitizedTitle = test.title.replace(/[^\w\d]+/g, '_');
+  const assetPath = path.join(config.outputDir, relativePath, sanitizedTitle) + '-recording.mp4';
+
+  const recording = await saveVideo(page, assetPath);
+  await runTest(page);
+  await recording.stop();
+  await page.close();
+});
+
+it('is a basic test with the page', async ({page}) => {
+  await page.goto('https://github.com');
+  await page.type('input[name="q"]', 'Playwright');
+  await page.press('input[name="q"]', 'Enter');
+  await page.click('.repo-list-item:nth-child(1) a');
+});

--- a/examples/screenshot-on-failure/package.json
+++ b/examples/screenshot-on-failure/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "playwright-screenshot-on-failure",
+  "version": "1.0.0",
+  "directories": {
+    "test": "tests"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "playwright-runner": "^0.2.1"
+  },
+  "scripts": {
+    "test": "test-runner"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/examples/screenshot-on-failure/tests/playwright.spec.ts
+++ b/examples/screenshot-on-failure/tests/playwright.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import 'playwright-runner';
+import {registerFixture} from 'playwright-runner';
+
+registerFixture('page', async ({context}, runTest, info) => {
+  const page = await context.newPage();
+  await runTest(page);
+  const {test, config, result} = info;
+  if (result.status === 'failed' || result.status === 'timedOut') {
+    const relativePath = path.relative(config.testDir, test.file).replace(/\.spec\.[jt]s/, '');
+    const sanitizedTitle = test.title.replace(/[^\w\d]+/g, '_');
+    const assetPath = path.join(config.outputDir, relativePath, sanitizedTitle) + '-failed.png';
+    fs.mkdirSync(path.dirname(assetPath), {
+      recursive: true
+    });
+    await page.screenshot({ path: assetPath});
+  }
+  await page.close();
+});
+
+it('is a basic test with the page', async ({page}) => {
+  await page.setContent(`<div style="height: 500px; background-color: red">
+    Failed!
+  </div>`);
+  throw new Error('wrong!');
+});


### PR DESCRIPTION
Action items out of that for the future:
- Replace screen recording by native solution (in a few months)
- Abstract the logic for generating an output file replace / by - with test path + test name. Maybe add it to the test object.
- Page.screenshot lets maybe add directory creation to it like we do with Download.save?

We decided offline to not implement "screenshot on failure" directly so I would only add a general helper function for easier test-results generation.

We have to evaluate carefully which of these scenarios should be implemented natively to not end up in a bloated project.

Try to follow up with:
- Improve somehow the typings
- add docs for fixture / types
- add docs about setup.ts