### PR TITLE
feat: abstracted asset generation logic

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   test-examples:
     strategy:
+      fail-fast: false
       matrix:
         dir: [basic-js, basic-ts, browser-device-matrix, record-video, screenshot-on-failure]
     defaults:
@@ -20,5 +21,13 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 12.x
-    - run: npm install
+    - run: yarn
+      working-directory: .
+    - run: yarn link
+      working-directory: packages/playwright-runner
+    - run: yarn link
+      working-directory: packages/test-runner
+    - run: yarn link playwright-runner
+    - run: yarn link @playwright/test-runner
+    - run: yarn install
     - run: npm test

--- a/examples/browser-device-matrix/test/playwright.spec.ts
+++ b/examples/browser-device-matrix/test/playwright.spec.ts
@@ -14,25 +14,7 @@
  * limitations under the License.
  */
 
-import {registerWorkerFixture} from 'playwright-runner';
-import playwright from 'playwright';
-
-declare global {
-  interface FixtureParameters {
-    deviceName: string;
-  }
-}
-
-registerWorkerFixture('deviceName', async ({}, test) => {
-  await test(null);
-});
-
-registerWorkerFixture('defaultContextOptions', async ({deviceName}, test) => {
-  const device = typeof deviceName === 'string' ? playwright.devices[deviceName] : deviceName;
-  await test({
-    ...device
-  });
-});
+import 'playwright-runner';
 
 it('is a basic test with the page', async ({page}) => {
   await page.goto('http://whatsmyuseragent.org/');

--- a/examples/browser-device-matrix/test/setup.ts
+++ b/examples/browser-device-matrix/test/setup.ts
@@ -18,7 +18,7 @@ declare const matrix: (m: any) => void;
 
 matrix({
   'browserName': process.env.BROWSER ? [process.env.BROWSER] : ['chromium', 'webkit'],
-  'deviceName': process.env.DEVICE ? [process.env.DEVICE] : ['iPhone 11 Pro Max', 'Pixel 2 XL', {
+  'device': process.env.DEVICE ? [process.env.DEVICE] : ['iPhone 11 Pro Max', 'Pixel 2 XL', {
     'userAgent': 'Mozilla/5.0 (Linux; U; Android 4.3; en-us; SM-N900T Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
     'viewport': {
       'width': 360,

--- a/examples/record-video/tests/playwright.spec.ts
+++ b/examples/record-video/tests/playwright.spec.ts
@@ -16,15 +16,10 @@
 
 import {registerFixture} from 'playwright-runner';
 import {saveVideo} from 'playwright-video';
-import path from 'path';
 
-registerFixture('page', async ({context}, runTest, info) => {
+registerFixture('page', async ({context, outputFile}, runTest) => {
   const page = await context.newPage();
-  const {test, config} = info;
-  const relativePath = path.relative(config.testDir, test.file).replace(/\.spec\.[jt]s/, '');
-  const sanitizedTitle = test.title.replace(/[^\w\d]+/g, '_');
-  const assetPath = path.join(config.outputDir, relativePath, sanitizedTitle) + '-recording.mp4';
-
+  const assetPath = await outputFile('recording.mp4');
   const recording = await saveVideo(page, assetPath);
   await runTest(page);
   await recording.stop();

--- a/examples/screenshot-on-failure/tests/playwright.spec.ts
+++ b/examples/screenshot-on-failure/tests/playwright.spec.ts
@@ -14,22 +14,15 @@
  * limitations under the License.
  */
 
-import fs from 'fs';
-import path from 'path';
 import 'playwright-runner';
 import {registerFixture} from 'playwright-runner';
 
-registerFixture('page', async ({context}, runTest, info) => {
+registerFixture('page', async ({context, outputFile}, runTest, info) => {
   const page = await context.newPage();
   await runTest(page);
-  const {test, config, result} = info;
+  const {result} = info;
   if (result.status === 'failed' || result.status === 'timedOut') {
-    const relativePath = path.relative(config.testDir, test.file).replace(/\.spec\.[jt]s/, '');
-    const sanitizedTitle = test.title.replace(/[^\w\d]+/g, '_');
-    const assetPath = path.join(config.outputDir, relativePath, sanitizedTitle) + '-failed.png';
-    fs.mkdirSync(path.dirname(assetPath), {
-      recursive: true
-    });
+    const assetPath = await outputFile('failed.png');
     await page.screenshot({ path: assetPath});
   }
   await page.close();

--- a/packages/test-runner/src/cli.ts
+++ b/packages/test-runner/src/cli.ts
@@ -112,7 +112,7 @@ function collectFiles(testDir: string, dir: string, filters: string[]): string[]
       files.push(...collectFiles(testDir, path.join(dir, name), filters));
       continue;
     }
-    if (!name.endsWith('spec.ts'))
+    if (!name.endsWith('spec.ts') && !name.endsWith('spec.js'))
       continue;
     const relativeName = path.join(dir, name);
     const fullName = path.join(testDir, relativeName);

--- a/packages/test-runner/src/fixtures.ts
+++ b/packages/test-runner/src/fixtures.ts
@@ -15,9 +15,10 @@
  */
 
 import debug from 'debug';
-import { RunnerConfig } from './runnerConfig';
+import {RunnerConfig} from './runnerConfig';
 import { serializeError, Test, TestResult } from './test';
 import { raceAgainstTimeout } from './util';
+
 
 type Scope = 'test' | 'worker';
 


### PR DESCRIPTION
Maybe only allow TypeScript and fully drop JavaScript support?

Moved deviceName handling also into the playwright runner project.