### PR TITLE
fix: exit code on parse error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,25 +1,13 @@
-# This is a basic workflow to help you get started with Actions
-
-name: CI
-
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+name: Build
 on:
   push:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
@@ -35,10 +23,15 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-yarn-
     - uses: microsoft/playwright-github-action@v1
-
     - name: Install dependencies and build
       run: yarn
     - name: lint
       run: yarn lint
+    - run: yarn link
+      working-directory: packages/playwright-runner
+    - run: yarn link
+      working-directory: packages/test-runner
+    - run: yarn link playwright-runner
+    - run: yarn link @playwright/test-runner
     - name: test
       run: yarn test

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -1,4 +1,4 @@
-name: Examples
+name: Test Examples
 on:
   push:
     branches: [ master ]
@@ -24,10 +24,11 @@ jobs:
     - run: yarn
       working-directory: .
     - run: yarn link
-      working-directory: packages/playwright-runner
-    - run: yarn link
       working-directory: packages/test-runner
+    - run: |
+        yarn link
+        yarn link @playwright/test-runner
+      working-directory: packages/playwright-runner
     - run: yarn link playwright-runner
-    - run: yarn link @playwright/test-runner
     - run: yarn install
-    - run: npm test
+    - run: yarn test

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Place unit tests in files ending with `.spec.*`.
 ```js
 // src/foo.spec.ts
 import 'playwright-runner';
+import { it, expect } from '@playwright/test-runner';
+
 
 it('is a basic test with the page', async ({page}) => {
   await page.goto('https://playwright.dev/');

--- a/examples/basic-ts/tests/playwright.spec.ts
+++ b/examples/basic-ts/tests/playwright.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import 'playwright-runner';
+import {it, expect} from '@playwright/test-runner';
 
 it('is a basic test with the page', async ({page}) => {
   await page.goto('https://playwright.dev/');

--- a/examples/browser-device-matrix/test/playwright.spec.ts
+++ b/examples/browser-device-matrix/test/playwright.spec.ts
@@ -15,7 +15,9 @@
  */
 
 import 'playwright-runner';
+import {it, expect} from '@playwright/test-runner';
 
 it('is a basic test with the page', async ({page}) => {
-  await page.goto('http://whatsmyuseragent.org/');
+  await page.goto('https://playwright.dev/');
+  expect(await page.innerText('.home-navigation')).toBe('🎭 Playwright');
 });

--- a/examples/record-video/tests/playwright.spec.ts
+++ b/examples/record-video/tests/playwright.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import {registerFixture} from 'playwright-runner';
+import {it} from '@playwright/test-runner';
 import {saveVideo} from 'playwright-video';
 
 registerFixture('page', async ({context, outputFile}, runTest) => {

--- a/examples/screenshot-on-failure/tests/playwright.spec.ts
+++ b/examples/screenshot-on-failure/tests/playwright.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import 'playwright-runner';
-import {registerFixture} from 'playwright-runner';
+import {it, registerFixture, expect} from '@playwright/test-runner';
 
 registerFixture('page', async ({context, outputFile}, runTest, info) => {
   const page = await context.newPage();
@@ -30,7 +30,7 @@ registerFixture('page', async ({context, outputFile}, runTest, info) => {
 
 it('is a basic test with the page', async ({page}) => {
   await page.setContent(`<div style="height: 500px; background-color: red">
-    Failed!
+    The red background is real!
   </div>`);
-  throw new Error('wrong!');
+  expect(await page.innerText('body')).toBe('Nooo!');
 });

--- a/packages/playwright-runner/README.md
+++ b/packages/playwright-runner/README.md
@@ -4,11 +4,13 @@
 
 A test runner for running tests with Playwright.
 
-1. `npm i playwright-runner`
+1. `npm i -D playwright-runner`
 2. Place unit tests in files ending with `.spec.*`.
 ```js
 // src/foo.spec.ts
 import 'playwright-runner';
+import { it, expected } from '@playwright/test-runner';
+
 it('is a basic test with the page', async ({page}) => {
   await page.goto('https://playwright.dev/');
   const home = await page.waitForSelector('home-navigation');

--- a/packages/test-runner/src/cli.ts
+++ b/packages/test-runner/src/cli.ts
@@ -85,7 +85,13 @@ program
       });
 
       const files = collectFiles(testDir, '', command.args.slice(1), command.testMatch, command.testIgnore);
-      const result = await run(config, files, new Multiplexer(reporterObjects));
+      let result;
+      try {
+        result = await run(config, files, new Multiplexer(reporterObjects));
+      } catch (err) {
+        console.error(err);
+        process.exit(1);
+      }
       if (result === 'forbid-only') {
         console.error('=====================================');
         console.error(' --forbid-only found a focused test.');

--- a/packages/test-runner/test/assets/is-not-defined-error.ts
+++ b/packages/test-runner/test/assets/is-not-defined-error.ts
@@ -13,11 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-require('playwright-runner');
-const { it, expect } = require('@playwright/test-runner');
-
-it('is a basic test with the page', async ({page}) => {
-  await page.goto('https://playwright.dev/');
-  expect(await page.innerText('.home-navigation')).toBe('🎭 Playwright');
-});
+foo();

--- a/packages/test-runner/test/exit-code.spec.ts
+++ b/packages/test-runner/test/exit-code.spec.ts
@@ -26,6 +26,16 @@ it('should collect stdio', async ({ runTest }) => {
   expect(stderr).toEqual([{ text: 'stderr text' }, { buffer: Buffer.from('stderr buffer').toString('base64') }]);
 });
 
+it('should work with not defined errors', async ({runTest}) => {
+  let error;
+  try {
+    const result = await runTest('is-not-defined-error.ts');
+  } catch (err) {
+    error = err;
+  }
+  expect(error.exitCode).toBe(1);
+});
+
 it('should work with typescript', async ({ runTest }) => {
   const result = await runTest('typescript.ts');
   expect(result.exitCode).toBe(0);

--- a/packages/test-runner/test/fixtures.ts
+++ b/packages/test-runner/test/fixtures.ts
@@ -61,7 +61,9 @@ async function runTest(reportFile: string, outputDir: string, filePath: string, 
   try {
     report = JSON.parse(fs.readFileSync(reportFile).toString());
   } catch (e) {
-    throw new Error(outputStr);
+    const error = new Error(outputStr);
+    (error as any).exitCode = status;
+    throw error;
   }
   return {
     exitCode: status,


### PR DESCRIPTION
Drive-by: Use tip-of-tree version of test-runner to test the test-runner instead of the version on NPM.