### PR TITLE
types: switch from declare global to explicit templates

### DIFF
--- a/packages/test-runner/src/spec.ts
+++ b/packages/test-runner/src/spec.ts
@@ -23,42 +23,22 @@ let currentItImpl;
 let currentDescribeImpl;
 let currentSuites: Suite[];
 
-interface DescribeFunction {
-  describe(name: string, inner: () => void): void;
-  describe(name: string, modifier: (suite: Suite) => any, inner: () => void): void;
-}
-
-interface ItFunction<STATE> {
-  it(name: string, inner: (state: STATE) => Promise<void> | void): void;
-  it(name: string, modifier: (test: Test) => any, inner: (state: STATE) => Promise<void> | void): void;
-}
-
-export const it: ItFunction<TestState & WorkerState>['it'] & {
-  only: ItFunction<TestState & WorkerState>['it'];
-  skip: ItFunction<TestState & WorkerState>['it'];
-} = (...args) => {
+export const it = (...args) => {
   currentItImpl('default', ...args);
 };
 it.skip = (...args) => currentItImpl('skip', ...args);
 it.only = (...args) => currentItImpl('only', ...args);
-export const fit: ItFunction<TestState & WorkerState>['it'] = it.only;
-export const xit: ItFunction<TestState & WorkerState>['it'] = it.skip;
 
-export const describe: DescribeFunction['describe'] & {
-  only: DescribeFunction['describe'];
-  skip: DescribeFunction['describe'];
-} = (...args) => {
+export const describe = (...args) => {
   currentDescribeImpl('default', ...args);
 };
 describe.skip = (...args) => currentDescribeImpl('skip', ...args);
 describe.only = (...args) => currentDescribeImpl('only', ...args);
-export const fdescribe: DescribeFunction['describe'] = describe.only;
-export const xdescribe: DescribeFunction['describe'] = describe.skip;
 
-export const beforeEach: (inner: (state: TestState & WorkerState) => Promise<void>) => void = fn => currentSuites[0]._addHook('beforeEach', fn);
-export const afterEach: (inner: (state: TestState & WorkerState) => Promise<void>) => void = fn => currentSuites[0]._addHook('afterEach', fn);
-export const beforeAll: (inner: (state: WorkerState) => Promise<void>) => void = fn => currentSuites[0]._addHook('beforeAll', fn);
-export const afterAll: (inner: (state: WorkerState) => Promise<void>) => void = fn => currentSuites[0]._addHook('afterAll', fn);
+export const beforeEach = fn => currentSuites[0]._addHook('beforeEach', fn);
+export const afterEach = fn => currentSuites[0]._addHook('afterEach', fn);
+export const beforeAll = fn => currentSuites[0]._addHook('beforeAll', fn);
+export const afterAll = fn => currentSuites[0]._addHook('afterAll', fn);
 
 export function spec(suite: Suite, file: string, timeout: number): () => void {
   const suites = [suite];

--- a/packages/test-runner/test/assets/export-type-only.fixtures.ts
+++ b/packages/test-runner/test/assets/export-type-only.fixtures.ts
@@ -14,20 +14,19 @@
  * limitations under the License.
  */
 
-const { it, registerWorkerFixture } = require('../..');
+import { fixtures as imported } from '../..';
 
-registerWorkerFixture('fixture', async ({}, runTest) => {
-  await runTest('');
+export type TypeOnlyState = {
+  test: { testTypeOnly: string },
+  worker: { workerTypeOnly: number },
+};
+
+const fixtures = imported.extend<TypeOnlyState>();
+
+fixtures.registerFixture('testTypeOnly', async ({config}, runTest, info) => {
+  await runTest('testTypeOnly');
 });
 
-it('test that uses fixture', async ({fixture}) => {
-  console.log('test that uses fixture');
-});
-
-it('test that does not use fixtures', async ({}) => {
-  console.log('test that does not use fixtures');
-});
-
-it('test that uses fixture 2', async ({fixture}) => {
-  console.log('another test that uses fixture');
+fixtures.registerWorkerFixture('workerTypeOnly', async ({parallelIndex}, runTest, info) => {
+  await runTest(42);
 });

--- a/packages/test-runner/test/assets/export-type-only.fixtures.ts
+++ b/packages/test-runner/test/assets/export-type-only.fixtures.ts
@@ -16,12 +16,14 @@
 
 import { fixtures as imported } from '../..';
 
-export type TypeOnlyState = {
-  test: { testTypeOnly: string },
-  worker: { workerTypeOnly: number },
+export type TypeOnlyTestState = {
+  testTypeOnly: string;
+};
+export type TypeOnlyWorkerState = {
+  workerTypeOnly: number;
 };
 
-const fixtures = imported.extend<TypeOnlyState>();
+const fixtures = imported.extend<TypeOnlyWorkerState, TypeOnlyTestState>();
 
 fixtures.registerFixture('testTypeOnly', async ({config}, runTest, info) => {
   await runTest('testTypeOnly');

--- a/packages/test-runner/test/assets/export-wrap.fixtures.ts
+++ b/packages/test-runner/test/assets/export-wrap.fixtures.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fixtures as imported } from '../..';
+
+export type WrapState = {
+  test: { testWrap: string },
+  worker: { workerWrap: number },
+};
+export const fixtures = imported.extend<WrapState>();
+
+export const it = fixtures.it;
+export const fit = fixtures.fit;
+export const xit = fixtures.xit;
+export const describe = fixtures.describe;
+export const fdescribe = fixtures.fdescribe;
+export const xdescribe = fixtures.xdescribe;
+export const beforeEach = fixtures.beforeEach;
+export const afterEach = fixtures.afterEach;
+export const beforeAll = fixtures.beforeAll;
+export const afterAll = fixtures.afterAll;
+export const parameters = fixtures.parameters;
+export const expect = fixtures.expect;
+
+fixtures.registerFixture('testWrap', async ({config}, runTest, info) => {
+  await runTest('testWrap');
+});
+
+fixtures.registerWorkerFixture('workerWrap', async ({parallelIndex}, runTest, info) => {
+  await runTest(42);
+});

--- a/packages/test-runner/test/assets/export-wrap.fixtures.ts
+++ b/packages/test-runner/test/assets/export-wrap.fixtures.ts
@@ -16,11 +16,13 @@
 
 import { fixtures as imported } from '../..';
 
-export type WrapState = {
-  test: { testWrap: string },
-  worker: { workerWrap: number },
+type WrapWorkerState = {
+  workerWrap: number;
 };
-export const fixtures = imported.extend<WrapState>();
+type WrapTestState = {
+  testWrap: string;
+};
+export const fixtures = imported.extend<WrapWorkerState, WrapTestState>();
 
 export const it = fixtures.it;
 export const fit = fixtures.fit;

--- a/packages/test-runner/test/assets/fixture-timeout.js
+++ b/packages/test-runner/test/assets/fixture-timeout.js
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-const { it, expect, registerFixture } = require('../../');
+const { it, expect, fixtures } = require('../../');
 
-registerFixture('timeout', async ({}, runTest) => {
+fixtures.registerFixture('timeout', async ({}, runTest) => {
   await runTest();
   await new Promise(f => setTimeout(f, 100000));
 });

--- a/packages/test-runner/test/assets/import-fixtures-both.ts
+++ b/packages/test-runner/test/assets/import-fixtures-both.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fixtures } from './export-wrap.fixtures';
+import { TypeOnlyState } from './export-type-only.fixtures';
+const { overrideFixture, overrideWorkerFixture, it, expect } = fixtures.extend<TypeOnlyState>();
+
+overrideFixture('testWrap', async ({}, runTest, info) => {
+  await runTest('override');
+});
+
+overrideWorkerFixture('workerTypeOnly', async ({}, runTest, info) => {
+  await runTest(17);
+});
+
+it('ensure that overrides work', async ({ testTypeOnly, workerTypeOnly, testWrap, workerWrap }) => {
+  expect(testWrap).toBe('override');
+  expect(workerWrap).toBe(42);
+  expect(testTypeOnly).toBe('testTypeOnly');
+  expect(workerTypeOnly).toBe(17);
+});

--- a/packages/test-runner/test/assets/import-fixtures-both.ts
+++ b/packages/test-runner/test/assets/import-fixtures-both.ts
@@ -15,8 +15,8 @@
  */
 
 import { fixtures } from './export-wrap.fixtures';
-import { TypeOnlyState } from './export-type-only.fixtures';
-const { overrideFixture, overrideWorkerFixture, it, expect } = fixtures.extend<TypeOnlyState>();
+import { TypeOnlyWorkerState, TypeOnlyTestState } from './export-type-only.fixtures';
+const { overrideFixture, overrideWorkerFixture, it, expect } = fixtures.extend<TypeOnlyWorkerState, TypeOnlyTestState>();
 
 overrideFixture('testWrap', async ({}, runTest, info) => {
   await runTest('override');

--- a/packages/test-runner/test/assets/import-fixtures-type-only.ts
+++ b/packages/test-runner/test/assets/import-fixtures-type-only.ts
@@ -14,20 +14,19 @@
  * limitations under the License.
  */
 
-const { it, registerWorkerFixture } = require('../..');
+import { fixtures } from '../..';
+import { TypeOnlyState } from './export-type-only.fixtures';
+const { it, expect, overrideFixture } = fixtures.extend<TypeOnlyState>();
 
-registerWorkerFixture('fixture', async ({}, runTest) => {
-  await runTest('');
+// Should be able to use state definition.
+const foo: TypeOnlyState['worker']['workerTypeOnly'] = 17;
+
+overrideFixture('testTypeOnly', async ({}, runTest, info) => {
+  await runTest('override');
 });
 
-it('test that uses fixture', async ({fixture}) => {
-  console.log('test that uses fixture');
-});
-
-it('test that does not use fixtures', async ({}) => {
-  console.log('test that does not use fixtures');
-});
-
-it('test that uses fixture 2', async ({fixture}) => {
-  console.log('another test that uses fixture');
+it('ensure that override works', async ({ testTypeOnly, workerTypeOnly }) => {
+  expect(foo).toBe(17);
+  expect(testTypeOnly).toBe('override');
+  expect(workerTypeOnly).toBe(42);
 });

--- a/packages/test-runner/test/assets/import-fixtures-type-only.ts
+++ b/packages/test-runner/test/assets/import-fixtures-type-only.ts
@@ -15,18 +15,14 @@
  */
 
 import { fixtures } from '../..';
-import { TypeOnlyState } from './export-type-only.fixtures';
-const { it, expect, overrideFixture } = fixtures.extend<TypeOnlyState>();
-
-// Should be able to use state definition.
-const foo: TypeOnlyState['worker']['workerTypeOnly'] = 17;
+import { TypeOnlyWorkerState, TypeOnlyTestState } from './export-type-only.fixtures';
+const { it, expect, overrideFixture } = fixtures.extend<TypeOnlyWorkerState, TypeOnlyTestState>();
 
 overrideFixture('testTypeOnly', async ({}, runTest, info) => {
   await runTest('override');
 });
 
 it('ensure that override works', async ({ testTypeOnly, workerTypeOnly }) => {
-  expect(foo).toBe(17);
   expect(testTypeOnly).toBe('override');
   expect(workerTypeOnly).toBe(42);
 });

--- a/packages/test-runner/test/assets/import-fixtures-wrap.ts
+++ b/packages/test-runner/test/assets/import-fixtures-wrap.ts
@@ -14,20 +14,24 @@
  * limitations under the License.
  */
 
-const { it, registerWorkerFixture } = require('../..');
+import { fixtures, WrapState, it, expect } from './export-wrap.fixtures';
 
-registerWorkerFixture('fixture', async ({}, runTest) => {
-  await runTest('');
+// Should be able to use state definition.
+const foo: WrapState['worker']['workerWrap'] = 17;
+
+fixtures.overrideFixture('testWrap', async ({}, runTest, info) => {
+  await runTest('override');
 });
 
-it('test that uses fixture', async ({fixture}) => {
-  console.log('test that uses fixture');
+fixtures.it('ensure that testRunner.* work', async ({}) => {
+  fixtures.expect(foo).toBe(17);
 });
 
-it('test that does not use fixtures', async ({}) => {
-  console.log('test that does not use fixtures');
+it('ensure that exported members work', async ({}) => {
+  expect(foo).toBe(17);
 });
 
-it('test that uses fixture 2', async ({fixture}) => {
-  console.log('another test that uses fixture');
+it('ensure that override works', async ({ testWrap, workerWrap }) => {
+  expect(testWrap).toBe('override');
+  expect(workerWrap).toBe(42);
 });

--- a/packages/test-runner/test/assets/import-fixtures-wrap.ts
+++ b/packages/test-runner/test/assets/import-fixtures-wrap.ts
@@ -14,21 +14,18 @@
  * limitations under the License.
  */
 
-import { fixtures, WrapState, it, expect } from './export-wrap.fixtures';
-
-// Should be able to use state definition.
-const foo: WrapState['worker']['workerWrap'] = 17;
+import { fixtures, it, expect } from './export-wrap.fixtures';
 
 fixtures.overrideFixture('testWrap', async ({}, runTest, info) => {
   await runTest('override');
 });
 
 fixtures.it('ensure that testRunner.* work', async ({}) => {
-  fixtures.expect(foo).toBe(17);
+  fixtures.expect(1).toBe(1);
 });
 
 it('ensure that exported members work', async ({}) => {
-  expect(foo).toBe(17);
+  expect(2).toBe(2);
 });
 
 it('ensure that override works', async ({ testWrap, workerWrap }) => {

--- a/packages/test-runner/test/assets/test-data-visible-in-fixture.ts
+++ b/packages/test-runner/test/assets/test-data-visible-in-fixture.ts
@@ -16,7 +16,7 @@
 
 import { fixtures } from '../../';
 
-const { registerFixture, it, expect } = fixtures.extend<{ test: { postProcess: string } }>();
+const { registerFixture, it, expect } = fixtures.extend<{ postProcess: string }>();
 
 registerFixture('postProcess', async ({}, runTest, info) => {
   await runTest('');

--- a/packages/test-runner/test/assets/test-data-visible-in-fixture.ts
+++ b/packages/test-runner/test/assets/test-data-visible-in-fixture.ts
@@ -14,13 +14,9 @@
  * limitations under the License.
  */
 
-import { it, expect, registerFixture } from '../../';
+import { fixtures } from '../../';
 
-declare global {
-  interface TestState {
-    postProcess: string;
-  }
-}
+const { registerFixture, it, expect } = fixtures.extend<{ test: { postProcess: string } }>();
 
 registerFixture('postProcess', async ({}, runTest, info) => {
   await runTest('');

--- a/packages/test-runner/test/assets/test-error-visible-in-fixture.ts
+++ b/packages/test-runner/test/assets/test-error-visible-in-fixture.ts
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 
-import { it, expect, registerFixture } from '../../';
-const fs = require('fs');
-const path = require('path');
+import { fixtures } from '../../';
+import * as fs from 'fs';
+import * as path from 'path';
 
-declare global {
-  interface TestState {
-    postProcess: string;
-  }
-}
+const { it, registerFixture, expect } = fixtures.extend<{ test: { postProcess: string } }>();
 
 registerFixture('postProcess', async ({}, runTest, info) => {
   await runTest('');

--- a/packages/test-runner/test/assets/test-error-visible-in-fixture.ts
+++ b/packages/test-runner/test/assets/test-error-visible-in-fixture.ts
@@ -18,7 +18,7 @@ import { fixtures } from '../../';
 import * as fs from 'fs';
 import * as path from 'path';
 
-const { it, registerFixture, expect } = fixtures.extend<{ test: { postProcess: string } }>();
+const { it, registerFixture, expect } = fixtures.extend<{ postProcess: string }>();
 
 registerFixture('postProcess', async ({}, runTest, info) => {
   await runTest('');

--- a/packages/test-runner/test/types.spec.ts
+++ b/packages/test-runner/test/types.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { it, expect } from '@playwright/test-runner';
+import './fixtures';
+
+it('should be able to import/export wrapped fixtures', async ({ runTest }) => {
+  const { exitCode, passed } = await runTest('import-fixtures-wrap.ts');
+  expect(passed).toBe(3);
+  expect(exitCode).toBe(0);
+});
+
+it('should be able to import/export type-only fixtures', async ({ runTest }) => {
+  const { exitCode, passed } = await runTest('import-fixtures-type-only.ts');
+  expect(passed).toBe(1);
+  expect(exitCode).toBe(0);
+});
+
+it('should be able to import/export both wrapped and type-only fixtures', async ({ runTest }) => {
+  const { exitCode, passed } = await runTest('import-fixtures-both.ts');
+  expect(passed).toBe(1);
+  expect(exitCode).toBe(0);
+});
+
+// TODO: add tests for tsc enforcing various fixture types.


### PR DESCRIPTION
See tests for example use:
- `export-wrap.fixtures` and `import-fixtures-wrap` define a full-scale wrapper around a test runner;
- `export-type-only.fixtures` and `import-fixtures-type-only` define a lightweight fixtures pack with types;
- `import-fixtures-both` uses both.