### PR TITLE
fix: examples on bots

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -29,6 +29,9 @@ jobs:
         yarn link
         yarn link @playwright/test-runner
       working-directory: packages/playwright-runner
-    - run: yarn link playwright-runner
+    - run: |
+        yarn link playwright-runner
+        yarn link @playwright/test-runner
     - run: yarn install
     - run: yarn test
+      continue-on-error: ${{ matrix.dir == 'screenshot-on-failure' }}

--- a/packages/test-runner/test/fixtures.ts
+++ b/packages/test-runner/test/fixtures.ts
@@ -41,6 +41,7 @@ async function runTest(reportFile: string, outputDir: string, filePath: string, 
     path.join(__dirname, 'assets', filePath),
     '--output=' + outputDir,
     '--reporter=dot,json',
+    '--jobs=2',
     ...Object.keys(params).map(key => `--${key}=${params[key]}`)
   ], {
     env: {


### PR DESCRIPTION
Fixes the issue that Playwright Runner has used the test runner from node modules. That lead to inconsistency that the version from NPM was used.