### PR TITLE
fix: exit with 1 if test dir/file does not exist

### DIFF
--- a/examples/browser-device-matrix/package.json
+++ b/examples/browser-device-matrix/package.json
@@ -10,7 +10,7 @@
     "playwright-runner": "^0.2.1"
   },
   "scripts": {
-    "test": "test-runner test"
+    "test": "test-runner tests"
   },
   "keywords": [],
   "author": "",

--- a/packages/test-runner/src/cli.ts
+++ b/packages/test-runner/src/cli.ts
@@ -84,9 +84,9 @@ program
         }
       });
 
-      const files = collectFiles(testDir, '', command.args.slice(1), command.testMatch, command.testIgnore);
       let result;
       try {
+        const files = collectFiles(testDir, '', command.args.slice(1), command.testMatch, command.testIgnore);
         result = await run(config, files, new Multiplexer(reporterObjects));
       } catch (err) {
         console.error(err);
@@ -113,6 +113,8 @@ program.parse(process.argv);
 
 function collectFiles(testDir: string, dir: string, filters: string[], testMatch: string, testIgnore: string): string[] {
   const fullDir = path.join(testDir, dir);
+  if (!fs.existsSync(fullDir))
+    throw new Error(`${fullDir} does not exist`);
   if (fs.statSync(fullDir).isFile())
     return [fullDir];
   const files = [];

--- a/packages/test-runner/test/exit-code.spec.ts
+++ b/packages/test-runner/test/exit-code.spec.ts
@@ -68,3 +68,7 @@ it('should respect global timeout', async ({ runTest }) => {
   expect(exitCode).toBe(1);
   expect(output).toContain('Timed out waiting 0.5s for the entire test run');
 });
+
+it('should exit with code 1 if the specified folder/file does not exist', async ({runTest}) => {
+  await expect(runTest('111111111111.js')).rejects.toThrowError(/111111111111.js does not exist/);
+});


### PR DESCRIPTION
Currently we log on errors in the try/catch block the whole error including stack trace. This might be confusing for the user, should we maybe only log the error.toString() instead?

Example that missing dir/file will return a 0: https://github.com/microsoft/playwright-runner/runs/1076478989#step:11:5