### PR TITLE
feat(reporter): remove testrunner internals from stack trace

### DIFF
--- a/packages/test-runner/test/basic.spec.ts
+++ b/packages/test-runner/test/basic.spec.ts
@@ -72,3 +72,16 @@ it('should respect focused tests', async ({ runTest }) => {
   expect(passed).toBe(4);
   expect(exitCode).toBe(0);
 });
+
+it('should have a small stack', async ({ runTest }) => {
+  const result = await runTest('one-failure.ts', {}, false);
+  const lines = result.output.split('\n');
+  const stackLines = lines.filter(x => /^\s+at /.test(x));
+  expect(stackLines.length).toBe(1);
+  expect([
+    // node 10
+    'at it (test/assets/one-failure.ts:20:17)',
+    // node 12+
+    'at test/assets/one-failure.ts:20:17',
+  ]).toContain(stackLines[0].trim());
+});

--- a/packages/test-runner/test/exit-code.spec.ts
+++ b/packages/test-runner/test/exit-code.spec.ts
@@ -27,7 +27,7 @@ it('should collect stdio', async ({ runTest }) => {
   expect(stderr).toEqual([{ text: 'stderr text' }, { buffer: Buffer.from('stderr buffer').toString('base64') }]);
 });
 
-it('should work with not defined errors', async ({runTest}) => { 
+it('should work with not defined errors', async ({runTest}) => {
   const result = await runTest('is-not-defined-error.ts');
   const { fileErrors } = result.report;
   expect(fileErrors.length).toBe(1);

--- a/packages/test-runner/test/fixtures.ts
+++ b/packages/test-runner/test/fixtures.ts
@@ -38,7 +38,7 @@ export type RunResult = {
   results: any[],
 };
 
-async function runTest(reportFile: string, outputDir: string, filePath: string, params: any = {}): Promise<RunResult> {
+async function runTest(reportFile: string, outputDir: string, filePath: string, params: any = {}, color = true): Promise<RunResult> {
   const testProcess = spawn('node', [
     path.join(__dirname, '..', 'cli.js'),
     path.resolve(__dirname, 'assets', filePath),
@@ -51,6 +51,8 @@ async function runTest(reportFile: string, outputDir: string, filePath: string, 
       ...process.env,
       PW_OUTPUT_DIR: outputDir,
       PWRUNNER_JSON_REPORT: reportFile,
+      FORCE_COLOR: color ? '1' : '0',
+      DEBUG_COLORS: color ? '1' : '0',
     }
   });
   let output = '';
@@ -104,7 +106,7 @@ async function runTest(reportFile: string, outputDir: string, filePath: string, 
 declare global {
   interface TestState {
     outputDir: string;
-    runTest: (filePath: string, options?: any) => Promise<RunResult>;
+    runTest: (filePath: string, options?: any, color?: boolean) => Promise<RunResult>;
     runInlineTest: (files: { [key: string]: string }, options?: any) => Promise<RunResult>;
     runInlineFixturesTest: (files: { [key: string]: string }, options?: any) => Promise<RunResult>;
   }
@@ -121,8 +123,8 @@ fixtures.defineTestFixture('runTest', async ({ outputDir }, testRun, testInfo) =
   await removeFolderAsync(outputDir).catch(e => { });
   // Print output on failure.
   let result: RunResult;
-  await testRun(async (filePath, options) => {
-    result = await runTest(reportFile, outputDir, filePath, options);
+  await testRun(async (filePath, options, color) => {
+    result = await runTest(reportFile, outputDir, filePath, options, color);
     return result;
   });
   if (testInfo.result.status !== testInfo.result.expectedStatus)


### PR DESCRIPTION
Starts stack traces at the test file, and makes paths relative to the current working directory.