### PR TITLE
fix(fixtures): isolate fixtures between files

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@types/node": "^10.17.29",
     "@types/rimraf": "^3.0.0",
+    "@types/source-map-support": "^0.5.3",
     "@typescript-eslint/eslint-plugin": "^4.0.1",
     "@typescript-eslint/parser": "^4.0.1",
     "eslint": "^7.8.1",

--- a/packages/test-runner/src/testCollector.ts
+++ b/packages/test-runner/src/testCollector.ts
@@ -50,9 +50,9 @@ export class TestCollector {
   }
 
   private _processSuite(suite: Suite) {
-    // Rerun registrations so that the registrations map pointed to the
-    // topmost overridden registrations.
-    rerunRegistrations(suite.file, 'worker');
+    // Rerun registrations so that only fixutres for this file
+    // are registred
+    rerunRegistrations(suite.file);
     const workerGeneratorConfigurations = new Map();
 
     // Name each test.

--- a/packages/test-runner/src/testRunner.ts
+++ b/packages/test-runner/src/testRunner.ts
@@ -134,7 +134,7 @@ export class TestRunner extends EventEmitter {
     this._suite._assignIds();
     this._loaded = true;
 
-    rerunRegistrations(this._suite.file, 'test');
+    rerunRegistrations(this._suite.file);
     await this._runSuite(this._suite);
     this._reportDone();
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1020,6 +1020,13 @@
     "@types/glob" "*"
     "@types/node" "*"
 
+"@types/source-map-support@^0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@types/source-map-support/-/source-map-support-0.5.3.tgz#acb6b3e499c20692552d16934c16162c84594e16"
+  integrity sha512-fvjMjVH8Rmokw2dWh1dkj90iX5R8FPjeZzjNH+6eFXReh0QnHFf1YBl3B0CF0RohIAA3SDRJsGeeUWKl6d7HqA==
+  dependencies:
+    source-map "^0.6.0"
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"


### PR DESCRIPTION
clears the fixture registry before re-registering fixtures. This means that fixtures cannot leak into tests that don't require them.

Also fixes a bug where fixture locations were corrupted by `source-map-support`.