### PR TITLE
fix(types): don't depend on the dom types for test-runner

### DIFF
--- a/packages/test-runner/tsconfig.json
+++ b/packages/test-runner/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
       "outDir": "out",
       "rootDir": "src",
-      "strict": false
+      "strict": false,
+      "lib": ["esnext"]
   },
   "exclude": [
       "out"


### PR DESCRIPTION
the test-runner runs in node, so it should not need the dom typings. We can't change playwright-testrunner because playwright needs dom types for element handles.