### PR TITLE
feat(error): report toplevel fire errors

### DIFF
--- a/packages/test-runner/src/reporter.ts
+++ b/packages/test-runner/src/reporter.ts
@@ -25,4 +25,5 @@ export interface Reporter {
   onTestEnd(test: Test, result: TestResult): void;
   onTimeout(timeout: number): void;
   onEnd(): void;
+  onParseError(file: string, error: any): void;
 }

--- a/packages/test-runner/src/reporters/multiplexer.ts
+++ b/packages/test-runner/src/reporters/multiplexer.ts
@@ -59,4 +59,9 @@ export class Multiplexer implements Reporter {
     for (const reporter of this._reporters)
       reporter.onEnd();
   }
+
+  onParseError(file: string, error: any) {
+    for (const reporter of this._reporters)
+      reporter.onParseError(file, error);
+  }
 }

--- a/packages/test-runner/test/exit-code.spec.ts
+++ b/packages/test-runner/test/exit-code.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import path from 'path';
 import { fixtures } from './fixtures';
 const { it, expect } = fixtures;
 
@@ -28,6 +29,8 @@ it('should collect stdio', async ({ runTest }) => {
 
 it('should work with not defined errors', async ({runTest}) => {
   const result = await runTest('is-not-defined-error.ts');
+  expect(result.report.parseError.error.message).toBe('foo is not defined');
+  expect(result.report.parseError.file).toBe(path.join(__dirname, 'assets', 'is-not-defined-error.ts'));
   expect(result.exitCode).toBe(1);
 });
 
@@ -67,5 +70,5 @@ it('should respect global timeout', async ({ runTest }) => {
 it('should exit with code 1 if the specified folder/file does not exist', async ({runTest}) => {
   const result = await runTest('111111111111.js');
   expect(result.exitCode).toBe(1);
-  expect(result.output).toContain('111111111111.js does not exist');
+  expect(result.report.parseError.error).toBe(`${path.join(__dirname, 'assets', '111111111111.js')} does not exist`);
 });

--- a/packages/test-runner/test/parameters.spec.ts
+++ b/packages/test-runner/test/parameters.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import path from 'path';
 import { fixtures } from './fixtures';
 const { it, expect } = fixtures;
 
@@ -37,5 +37,6 @@ it('should run with each configuration', async ({ runTest }) => {
 it('should fail on invalid parameters', async ({ runTest }) => {
   const result = await runTest('invalid-parameter');
   expect(result.exitCode).toBe(1);
-  expect(result.output).toContain(`Unregistered parameter 'invalid'`);
+  expect(result.report.parseError.file).toBe(path.join(__dirname, 'assets', 'invalid-parameter', 'setup'));
+  expect(result.report.parseError.error.message).toBe(`Unregistered parameter 'invalid' was set.`);
 });

--- a/packages/test-runner/test/register-parameter.spec.ts
+++ b/packages/test-runner/test/register-parameter.spec.ts
@@ -25,11 +25,9 @@ it('should allow custom parameters', async ({ runTest }) => {
 });
 
 it('should fail on unknown parameters', async ({ runTest }) => {
-  const result = await runTest('register-parameter.ts', {
+  const error = await runTest('register-parameter.ts', {
     'param1': 'value1',
     'param3': 'value3'
-  });
-  expect(result.exitCode).toBe(1);
-  expect(result.output).toContain('unknown option');
-  expect(result.output).toContain('param3');
+  }).catch(e => e);
+  expect(error.message).toContain(`unknown option '--param3=value3'`);
 });


### PR DESCRIPTION
This patch adds `onLoadingFailure` to the reporter api. It is fired when a test suite has an error upon being required. It appears in the report json as `loadingFailure`. Previously, no report would be generated.

Drive-by changes: JSONReporter no longer extends BaseReporter. The JSON report format is now typed.