### PR TITLE
fix(fixtures): use babel to parse dependencies

### DIFF
--- a/packages/test-runner/src/test.ts
+++ b/packages/test-runner/src/test.ts
@@ -269,6 +269,12 @@ export class Suite extends Runnable {
     return false;
   }
 
+  * allTests(): Iterable<Test> {
+    for (const suite of this.suites)
+      yield * suite.allTests();
+    yield * this.tests;
+  }
+
   _clone(): Suite {
     const suite = new Suite(this.title);
     suite._copyFrom(this);

--- a/packages/test-runner/src/test.ts
+++ b/packages/test-runner/src/test.ts
@@ -269,9 +269,9 @@ export class Suite extends Runnable {
     return false;
   }
 
-  * allTests(): Iterable<Test> {
+  * _allTests(): Iterable<Test> {
     for (const suite of this.suites)
-      yield * suite.allTests();
+      yield * suite._allTests();
     yield * this.tests;
   }
 

--- a/packages/test-runner/src/testCollector.ts
+++ b/packages/test-runner/src/testCollector.ts
@@ -18,13 +18,16 @@ import crypto from 'crypto';
 import { registrations, fixturesForCallback, rerunRegistrations } from './fixtures';
 import { Test, Suite, serializeConfiguration } from './test';
 import { RunnerConfig } from './runnerConfig';
-import { ReportFormat } from './reporters/json';
 
 export type Matrix = {
   [key: string]: string[]
 };
+type ParseResult = {
+  suite?: Suite,
+  parseError?: {error: any, file: string}
+}
 
-export function parseTests(suites: Suite[], matrix: Matrix, config: RunnerConfig): {suite?: Suite, parseError?: ReportFormat['parseError']} {
+export function parseTests(suites: Suite[], matrix: Matrix, config: RunnerConfig): ParseResult {
   const rootSuite = new Suite('');
   let grep: RegExp = null;
   if (config.grep) {
@@ -41,7 +44,7 @@ export function parseTests(suites: Suite[], matrix: Matrix, config: RunnerConfig
     // Name each test.
     suite._renumber();
 
-    for (const test of suite.allTests()) {
+    for (const test of suite._allTests()) {
       // Get all the fixtures that the test needs.
       let fixtures: string[];
       try {


### PR DESCRIPTION
depends on #115 

This uses babel instead of a regular expression to parse the first parameter of a function that uses fixtures. It also refactors the test collector to allow reporting a `parseError` when the argument cannot be parsed.