### PR TITLE
api: separate TestInfo api from Spec and friends

### DIFF
--- a/packages/test-runner/src/dispatcher.ts
+++ b/packages/test-runner/src/dispatcher.ts
@@ -93,7 +93,7 @@ export class Dispatcher {
           parameters: entry.parameters,
           parametersString: entry.parametersString,
           hash
-        });  
+        });
       }
     }
     result.sort((a, b) => a.hash < b.hash ? -1 : (a.hash === b.hash ? 0 : 1));

--- a/packages/test-runner/src/index.ts
+++ b/packages/test-runner/src/index.ts
@@ -157,12 +157,11 @@ fixtures.defineTestFixture('tmpDir', async ({}, test) => {
 
 fixtures.defineTestFixture('outputFile', async ({}, runTest, info) => {
   const outputFile = async (suffix: string): Promise<string> => {
-    const {config, spec: test} = info;
-    const relativePath = path.relative(config.testDir, test.file)
+    const relativePath = path.relative(info.config.testDir, info.file)
         .replace(/\.spec\.[jt]s/, '')
         .replace(new RegExp(`(tests|test|src)${path.sep}`), '');
-    const sanitizedTitle = test.title.replace(/[^\w\d]+/g, '_');
-    const assetPath = path.join(config.outputDir, relativePath, `${sanitizedTitle}-${suffix}`);
+    const sanitizedTitle = info.title.replace(/[^\w\d]+/g, '_');
+    const assetPath = path.join(info.config.outputDir, relativePath, `${sanitizedTitle}-${suffix}`);
     await mkdirAsync(path.dirname(assetPath), {
       recursive: true
     });

--- a/packages/test-runner/src/runner.ts
+++ b/packages/test-runner/src/runner.ts
@@ -57,6 +57,8 @@ export class Runner {
   }
 
   loadFiles(files: string[]) {
+    // Resolve symlinks. TODO: do this asynchronously?
+    files = files.map(file => fs.realpathSync(file));
     // First traverse tests.
     for (const file of files) {
       const suite = new RunnerSuite('');

--- a/packages/test-runner/src/runnerTest.ts
+++ b/packages/test-runner/src/runnerTest.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Spec, Suite, Test } from "./test";
+import { Spec, Suite, Test } from './test';
 
 export class RunnerSpec extends Spec {
   constructor(title: string, fn: Function, suite: RunnerSuite) {

--- a/packages/test-runner/src/test.ts
+++ b/packages/test-runner/src/test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Parameters, TestRun } from "./ipc";
+import { Parameters, TestRun } from './ipc';
 
 class Base {
   title: string;
@@ -144,7 +144,7 @@ export class Test {
       timeout: 0,
       workerId: 0,
       annotations: [],
-    
+
       duration: 0,
       stdout: [],
       stderr: [],

--- a/packages/test-runner/src/testGenerator.ts
+++ b/packages/test-runner/src/testGenerator.ts
@@ -39,7 +39,7 @@ export function generateTests(suites: RunnerSuite[], config: Config): RunnerSuit
     for (const test of suite._allSpecs()) {
       if (grep && !grep.test(test.fullTitle()))
         continue;
-    // Get all the fixtures that the test needs.
+      // Get all the fixtures that the test needs.
       let fixtures: string[] = [];
       try {
         fixtures = fixturesForCallback(test.fn);

--- a/packages/test-runner/src/testModifier.ts
+++ b/packages/test-runner/src/testModifier.ts
@@ -124,7 +124,7 @@ export class TestModifier {
   _isFlaky(): boolean {
     return this._flaky || (this._parent && this._parent._isFlaky());
   }
-й
+
   _computeExpectedStatus(): TestStatus {
     return this._expectedStatus || (this._parent && this._parent._computeExpectedStatus()) || 'passed';
   }

--- a/packages/test-runner/src/worker.ts
+++ b/packages/test-runner/src/worker.ts
@@ -28,18 +28,18 @@ if (!process.env.PW_RUNNER_DEBUG) {
     stderr: process.stderr,
     colorMode: process.env.FORCE_COLOR === '1',
   });
-  
+
   process.stdout.write = chunk => {
     if (testRunner)
       testRunner.stdout(chunk);
     return true;
   };
-  
+
   process.stderr.write = chunk => {
     if (testRunner)
       testRunner.stderr(chunk);
     return true;
-  };  
+  };
 }
 
 process.on('disconnect', gracefullyCloseAndExit);

--- a/packages/test-runner/src/workerTest.ts
+++ b/packages/test-runner/src/workerTest.ts
@@ -48,9 +48,9 @@ export class WorkerSuite extends Suite {
 
   _hasTestsToRun(): boolean {
     return this.findSpec((test: WorkerSpec) => {
-      if (!test._modifier._isSkipped()) {
+      if (!test._modifier._isSkipped())
         return true;
-      }
+
     });
   }
 }

--- a/packages/test-runner/test/assets/register-parameter.ts
+++ b/packages/test-runner/test/assets/register-parameter.ts
@@ -21,13 +21,23 @@ type Parameters = {
   param2: string;
 };
 
-const fixtures = baseFixtures.declareParameters<Parameters>();
+const fixtures = baseFixtures.declareParameters<Parameters>().declareTestFixtures<{ fixture1: string, fixture2: string}>();
 fixtures.defineParameter('param1', 'Custom parameter 1');
 fixtures.defineParameter('param2', 'Custom parameter 2', 'value2');
+fixtures.defineTestFixture('fixture1', async ({}, runTest, info) => {
+  await runTest(info.parameters.param1);
+});
+fixtures.defineTestFixture('fixture2', async ({}, runTest, info) => {
+  await runTest(info.parameters.param2);
+});
 
 const { it } = fixtures;
 
-it('pass', async ({ param1, param2 }) => {
+it('pass', async ({ param1, param2, fixture1, fixture2 }) => {
+  // Available as fixtures.
   expect(param1).toBe('value1');
   expect(param2).toBe('value2');
+  // Available as parameters to fixtures.
+  expect(fixture1).toBe('value1');
+  expect(fixture2).toBe('value2');
 });

--- a/packages/test-runner/test/assets/test-data-visible-in-fixture.ts
+++ b/packages/test-runner/test/assets/test-data-visible-in-fixture.ts
@@ -21,7 +21,7 @@ const { it, expect, defineTestFixture, defineWorkerFixture } = fixtures
 
 defineTestFixture('postProcess', async ({}, runTest, info) => {
   await runTest('');
-  info.testRun.data['myname'] = 'myvalue';
+  info.data['myname'] = 'myvalue';
 });
 
 defineWorkerFixture('config', async ({}, runTest, config) => {

--- a/packages/test-runner/test/assets/test-error-visible-in-fixture.ts
+++ b/packages/test-runner/test/assets/test-error-visible-in-fixture.ts
@@ -22,8 +22,7 @@ const { it, expect, defineTestFixture } = fixtures.declareTestFixtures<{ postPro
 
 defineTestFixture('postProcess', async ({}, runTest, info) => {
   await runTest('');
-  const { testRun } = info;
-  fs.writeFileSync(path.join(process.env.PW_OUTPUT_DIR, 'test-error-visible-in-fixture.txt'), JSON.stringify(testRun.error, undefined, 2));
+  fs.writeFileSync(path.join(process.env.PW_OUTPUT_DIR, 'test-error-visible-in-fixture.txt'), JSON.stringify(info.error, undefined, 2));
 });
 
 it('ensure fixture handles test error', async ({ postProcess }) => {


### PR DESCRIPTION
Possible follow up:
- move annotations from TestRun to Test;
- rename TestRun into TestResult;
- rename TestInfo into TestRun.