### PR TITLE
api: move stuff around

### DIFF
--- a/packages/test-runner/src/fixtures.ts
+++ b/packages/test-runner/src/fixtures.ts
@@ -50,11 +50,14 @@ export type TestInfo<WorkerParameters> = {
   annotations: any[];
 
   // Results
+  retryNumber: number;
   duration: number;
   status?: TestStatus;
   error?: any;
+  // TODO: do we need output here?
   stdout: (string | Buffer)[];
   stderr: (string | Buffer)[];
+  // TODO: type this as Object<string, any>.
   data: any;
 };
 

--- a/packages/test-runner/src/ipc.ts
+++ b/packages/test-runner/src/ipc.ts
@@ -18,15 +18,9 @@ export type Parameters = { name: string, value: string }[];
 
 export type TestStatus = 'passed' | 'failed' | 'timedOut' | 'skipped';
 
-export type TestRun = {
-  skipped: boolean;
-  flaky: boolean;
-  slow: boolean;
-  expectedStatus: TestStatus;
-  timeout: number;
+export type TestResult = {
+  retryNumber: number;
   workerIndex: number;
-  annotations: any[];
-
   duration: number;
   status?: TestStatus;
   error?: any;
@@ -35,20 +29,50 @@ export type TestRun = {
   data: any;
 };
 
+export type TestAnnotations = {
+  skipped: boolean;
+  flaky: boolean;
+  slow: boolean;
+  expectedStatus: TestStatus;
+  timeout: number;
+  annotations: any[];
+};
+
 export type TestBeginPayload = {
-  id: string;
-  testRun: TestRun;
+  testId: string;
+  retryNumber: number;
+  // Collected annotations, present for first run only (zero retryNumber).
+  annotations?: TestAnnotations;
 };
 
 export type TestEndPayload = {
-  id: string;
-  testRun: TestRun;
+  testId: string;
+  result: TestResult;
 };
 
-export type TestRunnerEntry = {
+export type TestEntry = {
+  testId: string;
+  retryNumber: number;
+  // Annotations are present for retries only (non-zero retryNumber).
+  annotations?: TestAnnotations;
+};
+
+export type RunPayload = {
   file: string;
-  ids: string[];
   parametersString: string;
   parameters: Parameters;
   hash: string;
+  entries: TestEntry[];
+};
+
+export type DonePayload = {
+  failedTestId?: string;
+  fatalError?: any;
+  remaining: TestEntry[];
+};
+
+export type TestOutputPayload = {
+  testId?: string;
+  text?: string;
+  buffer?: string;
 };

--- a/packages/test-runner/src/reporter.ts
+++ b/packages/test-runner/src/reporter.ts
@@ -1,4 +1,3 @@
-import { TestRun } from './ipc';
 /**
  * Copyright (c) Microsoft Corporation.
  *
@@ -17,13 +16,14 @@ import { TestRun } from './ipc';
 
 import { Config } from './config';
 import { Test, Suite } from './test';
+import { TestResult } from './ipc';
 
 export interface Reporter {
   onBegin(config: Config, suite: Suite): void;
   onTestBegin(test: Test): void;
   onTestStdOut(test: Test, chunk: string | Buffer): void;
   onTestStdErr(test: Test, chunk: string | Buffer): void;
-  onTestEnd(test: Test, result: TestRun): void;
+  onTestEnd(test: Test, result: TestResult): void;
   onTimeout(timeout: number): void;
   onError(error: any, file?: string): void;
   onEnd(): void;

--- a/packages/test-runner/src/reporters/dot.ts
+++ b/packages/test-runner/src/reporters/dot.ts
@@ -16,16 +16,16 @@
 
 import colors from 'colors/safe';
 import { BaseReporter } from './base';
-import { TestRun } from '../ipc';
+import { TestResult } from '../ipc';
 import { Test } from '../test';
 
 class DotReporter extends BaseReporter {
-  onTestEnd(test: Test, result: TestRun) {
+  onTestEnd(test: Test, result: TestResult) {
     super.onTestEnd(test, result);
     switch (result.status) {
       case 'skipped': process.stdout.write(colors.yellow('∘')); break;
-      case 'passed': process.stdout.write(result.status === result.expectedStatus ? colors.green('·') : colors.red('P')); break;
-      case 'failed': process.stdout.write(result.status === result.expectedStatus ? colors.green('f') : colors.red('F')); break;
+      case 'passed': process.stdout.write(result.status === test.expectedStatus ? colors.green('·') : colors.red('P')); break;
+      case 'failed': process.stdout.write(result.status === test.expectedStatus ? colors.green('f') : colors.red('F')); break;
       case 'timedOut': process.stdout.write(colors.red('T')); break;
     }
   }

--- a/packages/test-runner/src/reporters/json.ts
+++ b/packages/test-runner/src/reporters/json.ts
@@ -18,7 +18,7 @@ import * as fs from 'fs';
 import path from 'path';
 import { Config } from '../config';
 import { Reporter } from '../reporter';
-import { TestRun } from '../ipc';
+import { TestResult } from '../ipc';
 import { Test, Suite, Spec } from '../test';
 
 export interface SerializedSuite {
@@ -57,7 +57,7 @@ class JSONReporter implements Reporter {
   onTestBegin(test: Test): void {
   }
 
-  onTestEnd(test: Test, result: TestRun): void {
+  onTestEnd(test: Test, result: TestResult): void {
   }
 
   onError(error: any, file?: string): void {
@@ -95,18 +95,18 @@ class JSONReporter implements Reporter {
   private _serializeTest(test: Test) {
     return {
       parameters: test.parameters,
-      runs: test.runs.map(r => this._serializeTestRun(r))
+      slow: test.slow,
+      timeout: test.timeout,
+      annotations: test.annotations,
+      expectedStatus: test.expectedStatus,
+      // TODO: rename this to results.
+      runs: test.results.map(r => this._serializeTestResult(r)),
     };
   }
 
-  private _serializeTestRun(result: TestRun) {
+  private _serializeTestResult(result: TestResult) {
     return {
       workerIndex: result.workerIndex,
-      slow: result.slow,
-      timeout: result.timeout,
-      annotations: result.annotations,
-      expectedStatus: result.expectedStatus,
-
       status: result.status,
       duration: result.duration,
       error: result.error,

--- a/packages/test-runner/src/reporters/line.ts
+++ b/packages/test-runner/src/reporters/line.ts
@@ -17,7 +17,7 @@
 import * as path from 'path';
 import { Config } from '../config';
 import { BaseReporter } from './base';
-import { TestRun } from '../ipc';
+import { TestResult } from '../ipc';
 import { Test, Suite } from '../test';
 
 class LineReporter extends BaseReporter {
@@ -31,7 +31,7 @@ class LineReporter extends BaseReporter {
     console.log();
   }
 
-  onTestEnd(test: Test, result: TestRun) {
+  onTestEnd(test: Test, result: TestResult) {
     super.onTestEnd(test, result);
     const spec = test.spec;
     const baseName = path.basename(spec.file);

--- a/packages/test-runner/src/reporters/list.ts
+++ b/packages/test-runner/src/reporters/list.ts
@@ -19,7 +19,7 @@ import milliseconds from 'ms';
 import { BaseReporter } from './base';
 import { Config } from '../config';
 import { Suite, Test } from '../test';
-import { TestRun } from '../ipc';
+import { TestResult } from '../ipc';
 
 class ListReporter extends BaseReporter {
   private _failure = 0;
@@ -37,7 +37,7 @@ class ListReporter extends BaseReporter {
     this._testRows.set(test, this._lastRow++);
   }
 
-  onTestEnd(test: Test, result: TestRun) {
+  onTestEnd(test: Test, result: TestResult) {
     super.onTestEnd(test, result);
     const spec = test.spec;
 
@@ -47,7 +47,7 @@ class ListReporter extends BaseReporter {
       text = colors.green('  - ') + colors.cyan(spec.fullTitle());
     } else {
       const statusMark = result.status === 'passed' ? '  ✓ ' : '  x ';
-      if (result.status === result.expectedStatus)
+      if (result.status === test.expectedStatus)
         text = '\u001b[2K\u001b[0G' + colors.green(statusMark) + colors.gray(spec.fullTitle()) + duration;
       else
         text = '\u001b[2K\u001b[0G' + colors.red(`  ${++this._failure}) ` + spec.fullTitle()) + duration;

--- a/packages/test-runner/src/reporters/multiplexer.ts
+++ b/packages/test-runner/src/reporters/multiplexer.ts
@@ -17,7 +17,7 @@
 import { Config } from '../config';
 import { Reporter } from '../reporter';
 import { Suite, Test } from '../test';
-import { TestRun } from '../ipc';
+import { TestResult } from '../ipc';
 
 export class Multiplexer implements Reporter {
   private _reporters: Reporter[];
@@ -46,7 +46,7 @@ export class Multiplexer implements Reporter {
       reporter.onTestStdErr(test, chunk);
   }
 
-  onTestEnd(test: Test, result: TestRun) {
+  onTestEnd(test: Test, result: TestResult) {
     for (const reporter of this._reporters)
       reporter.onTestEnd(test, result);
   }

--- a/packages/test-runner/src/testModifier.ts
+++ b/packages/test-runner/src/testModifier.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { TestStatus } from './ipc';
+import { TestAnnotations, TestStatus } from './ipc';
 
 export class TestModifier {
   private _skipped = false;
@@ -133,6 +133,15 @@ export class TestModifier {
     if (!this._parent)
       return this._annotations;
     return [...this._annotations, ...this._parent._collectAnnotations()];
+  }
+
+  _fillAnnotations(annotations: TestAnnotations) {
+    this._skipped = annotations.skipped;
+    this._slow = annotations.slow;
+    this._flaky = annotations.flaky;
+    this._expectedStatus = annotations.expectedStatus;
+    this._timeout = annotations.timeout;
+    this._annotations = annotations.annotations;
   }
 
   private _interpretCondition(arg?: boolean | string, description?: string): { condition: boolean, description?: string } {

--- a/packages/test-runner/src/workerSpec.ts
+++ b/packages/test-runner/src/workerSpec.ts
@@ -22,7 +22,7 @@ import { TestModifier } from './testModifier';
 
 let currentRunSuites: WorkerSuite[];
 
-export function workerSpec(suite: WorkerSuite, timeout: number, parameters: any): () => void {
+export function workerSpec(suite: WorkerSuite, timeout: number, parameters: any, skipModifierFn: boolean): () => void {
   const suites = [suite];
   currentRunSuites = suites;
 
@@ -34,7 +34,7 @@ export function workerSpec(suite: WorkerSuite, timeout: number, parameters: any)
     }
     const test = new WorkerSpec(title, fn, suite);
     test._modifier.setTimeout(timeout);
-    if (modifierFn)
+    if (modifierFn && !skipModifierFn)
       modifierFn(test._modifier, parameters);
     test.file = suite.file;
     test.location = extractLocation(new Error());
@@ -49,7 +49,7 @@ export function workerSpec(suite: WorkerSuite, timeout: number, parameters: any)
       modifierFn = null;
     }
     const child = new WorkerSuite(title, suites[0]);
-    if (modifierFn)
+    if (modifierFn && !skipModifierFn)
       modifierFn(child._modifier, parameters);
     child.file = suite.file;
     child.location = extractLocation(new Error());

--- a/packages/test-runner/test/assets/retry-failures.js
+++ b/packages/test-runner/test/assets/retry-failures.js
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-const fs = require('fs');
-const path = require('path');
 const { fixtures } = require('../../');
 const { it, expect } = fixtures;
 
-it('flake', async ({}) => {
-  try {
-    fs.readFileSync(path.join(process.env.PW_OUTPUT_DIR, 'retry-failures.txt'));
-  } catch (e) {
-    // First time this fails.
-    fs.writeFileSync(path.join(process.env.PW_OUTPUT_DIR, 'retry-failures.txt'), 'TRUE');
-    expect(true).toBe(false);
-  }
+fixtures.defineTestFixture('retryNumber', async ({}, runTest, info) => {
+  await runTest(info.retryNumber);
+});
+
+it('flake', test => {
+  console.log('modifiers!');
+  test.slow('hey' + process.pid);
+}, async ({ retryNumber }) => {
+  // This only passed the second time.
+  expect(retryNumber).toBe(1);
 });

--- a/packages/test-runner/test/trial-run.spec.ts
+++ b/packages/test-runner/test/trial-run.spec.ts
@@ -83,7 +83,7 @@ it('should emit test annotations', async ({ runInlineTest }) => {
   }, { 'trial-run': true });
   expect(result.exitCode).toBe(0);
   expect(result.passed).toBe(1);
-  expect(result.report.suites[0].specs[0].tests[0].runs[0].annotations).toEqual([{ type: 'fail', description: 'Fail annotation' }]);
+  expect(result.report.suites[0].specs[0].tests[0].annotations).toEqual([{ type: 'fail', description: 'Fail annotation' }]);
 });
 
 it('should emit suite annotations', async ({ runInlineTest }) => {
@@ -100,7 +100,7 @@ it('should emit suite annotations', async ({ runInlineTest }) => {
   }, { 'trial-run': true });
   expect(result.exitCode).toBe(0);
   expect(result.skipped).toBe(1);
-  expect(result.report.suites[0].suites[0].specs[0].tests[0].runs[0].annotations).toEqual([{ type: 'fixme', description: 'Fix me!' }]);
+  expect(result.report.suites[0].suites[0].specs[0].tests[0].annotations).toEqual([{ type: 'fixme', description: 'Fix me!' }]);
 });
 
 it('should not restart worker', async ({ runInlineTest }) => {


### PR DESCRIPTION
- expose TestResult instead of TestRun;
- move annotations from TestRun to Test;
- pass around retryNumber;
- do not rerun modifierFn.